### PR TITLE
Add Pushover notification support and DISABLE_WITHDRAWAL option

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,8 +17,13 @@ MAX_FEE_RATE=100
 FEE_PREFERENCE=medium
 AUTO_RBF=1
 WITHDRAWAL_THRESHOLD_BTC=0.1
-# Set this to 1 do disable exchange deposits and go into withdraw-only mode.
+
+# BANK_RUN + DISABLE_WITHDRAWAL: You can only enable one of these at a time.
+#
+# Set this to 1 do disable exchange deposits. Does not do any sat-hunting and simply withdraws.
 BANK_RUN=1
+# Set this to 1 to disable exchange withdrawal. Hunt for sats and deposit to the exchange address only.
+DISABLE_WITHDRAWAL=0
 
 # Options are kraken, coinbase, coinbase_exchange, bitfinex, or binance
 ACTIVE_EXCHANGE=kraken
@@ -61,3 +66,7 @@ ACTIVE_EXCHANGE=kraken
 
 #TELEGRAM_BOT_TOKEN=
 #TELEGRAM_CHAT_ID=
+
+#PUSHOVER_TOKEN=
+#PUSHOVER_USER=
+#PUSHOVER_PRIORITY=-2

--- a/.env.sample
+++ b/.env.sample
@@ -21,7 +21,7 @@ WITHDRAWAL_THRESHOLD_BTC=0.1
 # BANK_RUN + DISABLE_WITHDRAWAL: You can only enable one of these at a time.
 #
 # Set this to 1 to disable exchange deposits. Does not do any sat-hunting, withdraw-only mode.
-BANK_RUN=1
+BANK_RUN=
 # Set this to 1 to disable exchange withdrawal. Hunt for sats and deposit to the exchange address only.
 DISABLE_WITHDRAWAL=0
 

--- a/.env.sample
+++ b/.env.sample
@@ -23,7 +23,7 @@ WITHDRAWAL_THRESHOLD_BTC=0.1
 # Set this to 1 to disable exchange deposits. Does not do any sat-hunting, withdraw-only mode.
 BANK_RUN=
 # Set this to 1 to disable exchange withdrawal. Hunt for sats and deposit to the exchange address only.
-DISABLE_WITHDRAWAL=0
+DISABLE_WITHDRAWAL=
 
 # Disables the broadcast notification
 OMIT_BROADCAST_MESSAGE=

--- a/.env.sample
+++ b/.env.sample
@@ -70,6 +70,7 @@ ACTIVE_EXCHANGE=kraken
 #TELEGRAM_BOT_TOKEN=
 #TELEGRAM_CHAT_ID=
 
+# Enable pushover notifications: (https://pushover.net/)
 #PUSHOVER_TOKEN=
 #PUSHOVER_USER=
 #PUSHOVER_PRIORITY=-2

--- a/notifications.js
+++ b/notifications.js
@@ -1,0 +1,46 @@
+const {
+  PUSHOVER_USER,
+  PUSHOVER_TOKEN,
+  PUSHOVER_PRIORITY,
+  TELEGRAM_BOT_TOKEN,
+  TELEGRAM_CHAT_ID
+} = process.env;
+
+const axios = require('axios');
+
+const TelegramBot = require('node-telegram-bot-api');
+const telegramBot = TELEGRAM_BOT_TOKEN ? new TelegramBot(TELEGRAM_BOT_TOKEN) : null;
+
+const PUSHOVER_ENABLED = PUSHOVER_USER && PUSHOVER_TOKEN;
+const PUSHOVER_ENDPOINT = 'https://api.pushover.net/1/messages.json';
+const PUSHOVER_DEFAULT_PRIORITY = 0;
+const TELEGRAM_BOT_ENABLED = telegramBot && TELEGRAM_CHAT_ID;
+
+const trySendPushover = (message = undefined) => {
+  if(!PUSHOVER_ENABLED || !message) return;
+  const priority = PUSHOVER_PRIORITY ?? PUSHOVER_DEFAULT_PRIORITY;
+  const headers = { 'Content-Type': 'application/json' };
+  axios.post(PUSHOVER_ENDPOINT, {
+    token: PUSHOVER_TOKEN,
+    user: PUSHOVER_USER,
+    message,
+    priority
+  }, { headers });
+};
+
+const trySendTelegram = (message = undefined) => {
+  if(!TELEGRAM_BOT_ENABLED || !message) return;
+  telegramBot.sendMessage(TELEGRAM_CHAT_ID, message);
+};
+
+
+const sendNotifications = (message = undefined) => {
+  trySendPushover(message);
+  trySendTelegram(message);
+};
+
+module.exports = {
+  PUSHOVER_ENABLED,
+  TELEGRAM_BOT_ENABLED,
+  sendNotifications
+};


### PR DESCRIPTION
Two features in this combined PR:

- Refactor the notification logic to allow for configuration of multiple notification services (Pushover + Telegram)

- Add a new DISABLE_WITHDRAWAL environment variable.
This will never withdraw, instead only depositing to the exchange. Cannot be combined with BANK_RUN mode.

New ENV vars:
- PUSHOVER_TOKEN
- PUSHOVER_USER
- PUSHOVER_PRIORITY
- DISABLE_WITHDRAWAL