### PR TITLE
chore: enforce engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,9 @@
       },
       "devDependencies": {
         "jest": "^29.7.0"
+      },
+      "engines": {
+        "node": ">=18.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "jest": "^29.7.0"
       },
       "engines": {
-        "node": ">=18.x"
+        "node": ">=18.x",
+        "npm": "9.x"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
       "./jest.setup.js"
     ]
   },
+  "engines": {
+    "node": ">=18.x"
+  },
+  "engineStrict": true,
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     ]
   },
   "engines": {
-    "node": ">=18.x"
+    "node": ">=18.x",
+    "npm": "9.x"
   },
   "engineStrict": true,
   "keywords": [],


### PR DESCRIPTION
- Add message with minimum node version 
- package-lock.json was removed and reinstalled with node 18, npm 9

![image](https://github.com/deezy-inc/sat-hunter/assets/126987350/e6a1c4a3-da40-40c6-a11d-c5dbcb339679)
