### PR TITLE
Revert new dependency of crypto-js and uuid

### DIFF
--- a/exchanges/coinbase-prime.js
+++ b/exchanges/coinbase-prime.js
@@ -1,8 +1,6 @@
 const axios = require('axios')
 const crypto = require('crypto')
 const totp = require("totp-generator")
-const CryptoJS = require('crypto-js');
-const uuid = require('uuid');
 
 const BASE_URL = 'https://api.prime.coinbase.com'
 
@@ -11,9 +9,11 @@ let PORTFOLIO_ID = null
 let ENTITY_ID = null
 
 function sign(str, secret) {
-    const hash = CryptoJS.HmacSHA256(str, secret);
-    return hash.toString(CryptoJS.enc.Base64);
+    const hmac = crypto.createHmac('sha256', secret);
+    hmac.update(str);
+    return hmac.digest('base64');
 }
+
 function buildPayload(ts, method, requestPath, body) {
     return `${ts}${method}${requestPath}${body}`;
 }
@@ -94,7 +94,7 @@ async function withdraw({ amount_btc }) {
         currency_symbol: 'BTC',
         portfolio_id: PORTFOLIO_ID,
         wallet_id: BTC_WALLET_ID,
-        idempotency_key: uuid.v4(),
+        idempotency_key: crypto.randomUUID(),
         destination_type: 'DESTINATION_BLOCKCHAIN',
         blockchain_address: {
             address: process.env.COINBASE_PRIME_WITHDRAWAL_ADDRESS,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,10 @@
         "bitcoin-address-validation": "^2.2.3",
         "bitcoinjs-lib": "^6.1.5",
         "bybit-api": "^3.7.3",
-        "crypto-js": "^4.2.0",
         "dotenv": "^16.3.1",
         "node-telegram-bot-api": "^0.63.0",
         "tiny-secp256k1": "^2.2.3",
-        "totp-generator": "^0.0.14",
-        "uuid": "^9.0.1"
+        "totp-generator": "^0.0.14"
       },
       "devDependencies": {
         "jest": "^29.7.0"
@@ -2029,11 +2027,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto-js": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -5271,18 +5264,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.3",

--- a/package.json
+++ b/package.json
@@ -31,12 +31,10 @@
     "bitcoin-address-validation": "^2.2.3",
     "bitcoinjs-lib": "^6.1.5",
     "bybit-api": "^3.7.3",
-    "crypto-js": "^4.2.0",
     "dotenv": "^16.3.1",
     "node-telegram-bot-api": "^0.63.0",
     "tiny-secp256k1": "^2.2.3",
-    "totp-generator": "^0.0.14",
-    "uuid": "^9.0.1"
+    "totp-generator": "^0.0.14"
   },
   "devDependencies": {
     "jest": "^29.7.0"


### PR DESCRIPTION
We dont want to introduce new dependencies that require npm install

Let this slip in https://github.com/deezy-inc/sat-hunter/pull/22