### PR TITLE
Clean up withdraw_requests file logic

### DIFF
--- a/storage.js
+++ b/storage.js
@@ -49,6 +49,11 @@ function save_withdraw_request(address, amount) {
 function process_first_withdrawal_request() {
     const filePath = `${data_dir}/withdraw_requests.json`
 
+    if (!fs.existsSync(filePath)) {
+        console.log('No withdraw_requests.json file to process.');
+        return null;
+    }
+
     // Read the file content
     let fileContent
     try {


### PR DESCRIPTION
Kept seeing a noisy error message in the logs when the `withdraw_requests.json` file does not exist. Would be nicer if we check that it exists before trying to read it and catching a read error