### PR TITLE
Allow multiple tag limits in bulk transfer

### DIFF
--- a/__tests__/commands.js
+++ b/__tests__/commands.js
@@ -1,4 +1,4 @@
-const { get_payment_details } = require('./../commands')
+const { get_payment_details, parse_tag_limits } = require('./../commands')
 const { get_user_limits } = require('./../deezy')
 
 jest.mock('./../deezy')
@@ -45,5 +45,50 @@ Payment Address:
         const result = await get_payment_details()
 
         expect(result).toBe('')
+    })
+})
+
+describe('parse_tag_limits', () => {
+    it('default tag limits', async () => {
+        expect(
+            parse_tag_limits({
+                tag_limits_arg: '100',
+                default_tag: 'uncommon',
+            })
+        ).toStrictEqual({
+            uncommon: 100,
+        })
+
+        expect(
+            parse_tag_limits({
+                tag_limits_arg: '20',
+                default_tag: 'black_uncommon',
+            })
+        ).toStrictEqual({
+            black_uncommon: 20,
+        })
+    })
+
+    it('multiple tag limits', async () => {
+        expect(
+            parse_tag_limits({
+                tag_limits_arg: 'uncommon:10,alpha:0',
+                default_tag: 'uncommon',
+            })
+        ).toStrictEqual({
+            uncommon: 10,
+            alpha: 0,
+        })
+
+        expect(
+            parse_tag_limits({
+                tag_limits_arg: 'pizza:100,palindrome:0,name_palindrome:0',
+                default_tag: 'pizza',
+            })
+        ).toStrictEqual({
+            pizza: 100,
+            palindrome: 0,
+            name_palindrome: 0,
+        })
     })
 })

--- a/commands.js
+++ b/commands.js
@@ -110,8 +110,8 @@ function parse_tag_limits({ tag_limits_arg, default_tag }) {
         const entries = tag_limits_arg.split(',')
         for (const entry of entries) {
             const [tag, num_str] = entry.split(':')
-            entry[tag] = parseInt(num_str)
-            if (isNaN(entry[tag])) {
+            tag_limits_object[tag] = parseInt(num_str)
+            if (isNaN(tag_limits_object[tag])) {
                 throw new Error(`Invalid tag limit: ${entry}`)
             }
         }

--- a/commands.js
+++ b/commands.js
@@ -106,7 +106,7 @@ async function loop_check_bulk_transfer(scan_request_id) {
 
 function parse_tag_limits({ tag_limits_arg, default_tag }) {
     const tag_limits_object = {}
-    if (isNaN(parseInt(tag_limits_arg)) {
+    if (isNaN(parseInt(tag_limits_arg))) {
         const entries = tag_limits_arg.split(',')
         for (const entry of entries) {
             const [tag, num_str] = entry.split(':')
@@ -121,14 +121,7 @@ function parse_tag_limits({ tag_limits_arg, default_tag }) {
     return tag_limits_object
 }
 
-const bulk_transfer = async (
-    p_from_address,
-    p_to_address,
-    p_tag_to_extract,
-    p_tag_limits,
-    p_fee_rate,
-    callbackMessage
-) => {
+const bulk_transfer = async (p_from_address, p_to_address, p_tag_to_extract, p_tag_limits, p_fee_rate, callbackMessage) => {
     const tag_limits = parse_tag_limits({ tag_limits_arg: p_tag_limits, default_tag: p_tag_to_extract })
     try {
         if (!p_from_address || !p_to_address || !p_tag_to_extract || !tag_limits || !p_fee_rate) {

--- a/commands.js
+++ b/commands.js
@@ -201,4 +201,5 @@ module.exports = {
     get_payment_details,
     create_withdraw_request,
     bulk_transfer,
+    parse_tag_limits,
 }

--- a/commands.js
+++ b/commands.js
@@ -104,37 +104,57 @@ async function loop_check_bulk_transfer(scan_request_id) {
     })
 }
 
+function parse_tag_limits({ tag_limits_arg, default_tag }) {
+    const tag_limits_object = {}
+    if (isNaN(parseInt(tag_limits_arg)) {
+        const entries = tag_limits_arg.split(',')
+        for (const entry of entries) {
+            const [tag, num_str] = entry.split(':')
+            entry[tag] = parseInt(num_str)
+            if (isNaN(entry[tag])) {
+                throw new Error(`Invalid tag limit: ${entry}`)
+            }
+        }
+    } else {
+        tag_limits_object[default_tag] = parseInt(tag_limits_arg)
+    }
+    return tag_limits_object
+}
+
 const bulk_transfer = async (
     p_from_address,
     p_to_address,
     p_tag_to_extract,
-    p_num_of_tag_to_send,
+    p_tag_limits,
     p_fee_rate,
     callbackMessage
 ) => {
+    const tag_limits = parse_tag_limits({ tag_limits_arg: p_tag_limits, default_tag: p_tag_to_extract })
     try {
-        if (!p_from_address || !p_to_address || !p_tag_to_extract || !p_num_of_tag_to_send || !p_fee_rate) {
+        if (!p_from_address || !p_to_address || !p_tag_to_extract || !tag_limits || !p_fee_rate) {
             console.log(`
-Usage: hunter:bulk-transfer [from_address] [to_address] [tag_to_extract] [num_of_tag_to_send] [fee_rate]
+Usage: hunter:bulk-transfer [from_address] [to_address] [tag_to_extract] [tag_limits] [fee_rate]
 
 - from_address: The blockchain address from which the tags will be extracted. This should be a valid address from which you have permission to transfer.
 - to_address: The destination blockchain address to which the tags will be sent. Ensure this address is correct to avoid loss of assets.
 - tag_to_extract: The specific tag or identifier of the assets to be transferred.
-- num_of_tag_to_send: The number of tags or assets to send to the destination address. This must be a positive integer.
+- tag_limits: The number of tags or assets to send to the destination address. This can either be a single positive integer, or a string like "uncommon:25,alpha:0" to set limits for multiple tags.
 - fee_rate: The fee rate for the transaction in satoshis per virtual byte (sat/vbyte). This rate affects how quickly the transaction is processed by the network.
 
-Example: hunter:bulk-transfer 1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa 3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy uncommon 100 30
+Examples:
+
+hunter:bulk-transfer 1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa 3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy uncommon 100 30
 
 This command will transfer 100 uncommon tags from address 1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa to 3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy with a fee rate of 30 sat/vbyte.
+
+hunter:bulk-transfer 1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa 3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy uncommon "uncommon:50,alpha:0" 30
+
+This command will transfer 50 uncommons (none of which are alpha) from address 1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa to 3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy with a fee rate of 30 sat/vbyte.
 `)
             return { message: 'Missing or invalid arguments. Please refer to the usage information above.' }
         }
         console.log('Bulk transfer called')
 
-        const num_of_tag_to_send = parseInt(p_num_of_tag_to_send)
-        if (isNaN(num_of_tag_to_send) || num_of_tag_to_send <= 0) {
-            throw new Error(`num_of_tag_to_send must be an integer and positive number, got ${p_num_of_tag_to_send}`)
-        }
         const fee_rate = parseFloat(p_fee_rate)
         if (isNaN(fee_rate) || fee_rate <= 0) {
             throw new Error(`fee_rate must be a positive number, got ${p_fee_rate}`)
@@ -148,9 +168,7 @@ This command will transfer 100 uncommon tags from address 1A1zP1eP5QGefi2DMPTfTL
             regular_funds_addresses: [p_from_address],
             special_sat_addresses: [p_to_address],
             extraction_fee_rate: fee_rate,
-            tag_limits: {
-                [p_tag_to_extract]: num_of_tag_to_send,
-            },
+            tag_limits,
             included_tags: [[p_tag_to_extract]],
         }
 
@@ -175,7 +193,7 @@ This command will transfer 100 uncommon tags from address 1A1zP1eP5QGefi2DMPTfTL
         return {
             message: get_success_scan_address_file({
                 scan_request_id,
-                transfer_message: `${num_of_tag_to_send} ${p_tag_to_extract}`,
+                transfer_message: `${p_tag_to_extract} with tag limits ${p_tag_limits} and fee rate ${fee_rate} sat/vbyte`,
             }),
         }
     } catch (error) {

--- a/scripts/bulk-transfer.js
+++ b/scripts/bulk-transfer.js
@@ -3,13 +3,13 @@ const { bulk_transfer } = require('../commands')
 const from_address_arg = process.argv[2]
 const to_address_arg = process.argv[3]
 const tag_to_extract_arg = process.argv[4]
-const num_of_tag_to_send_arg = process.argv[5]
+const tag_limits_arg = process.argv[5]
 const fee_rate_arg = process.argv[6]
 
-bulk_transfer(from_address_arg, to_address_arg, tag_to_extract_arg, num_of_tag_to_send_arg, fee_rate_arg)
+bulk_transfer(from_address_arg, to_address_arg, tag_to_extract_arg, tag_limits_arg, fee_rate_arg)
     .then((result) => {
         console.log(result.message)
     })
     .catch((error) => {
-        console.log(`Bulk transfer of ${num_of_tag_to_send_arg} ${tag_to_extract_arg} failed with error: ${error.message}`)
+        console.log(`Bulk transfer of ${tag_to_extract_arg} failed with error: ${error.message}`)
     })


### PR DESCRIPTION
This allows a user to set more complex `tag_limits` for their bulk transfer. A common example is when somebody wants to send uncommon sats, but _not_ alpha sats. To do this they can do:

```
hunter:bulk-transfer 1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa 3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy uncommon "uncommon:50,alpha:0" 30
```