### PR TITLE
Fix HSM rule generation

### DIFF
--- a/scripts/generate_coldcard_hsm_policy.js
+++ b/scripts/generate_coldcard_hsm_policy.js
@@ -88,17 +88,18 @@ const get_whitelist = () => {
 }
 
 const get_whitelist_rules = () => {
-    const rules = get_whitelist().map((item_address) => {
-        return {
-            description: item_address.description,
-            whitelist: [item_address.address],
+    const whitelistAddresses = get_whitelist().map((item_address) => item_address.address)
+    const rules = [
+        {
+            description: 'Combined Whitelist',
+            whitelist: [...new Set(whitelistAddresses)], // Ensure addresses are unique
             per_period: null,
             max_amount: null,
             users: [],
             local_conf: false,
             wallet: null,
-        }
-    })
+        },
+    ]
     return rules
 }
 


### PR DESCRIPTION
Previously we were creating an array of multiple whitelist rules, when instead we should have been creating a single whitelist rule with an array of all the addresses

Per https://coldcard.com/docs/hsm/rules/#whitelist-address

> You may specify a list of addresses in the whitelist field. The Coldcard will only apply the rule if all destination addresses of the PSBT transaction are included in the whitelist. This is a powerful feature when your target wallets that you control in the whitelist, such as emergency cold wallets.

This would only come up during testing if you found rare sats, generating a PSBT with multiple destinations, which currently results in a rejected txn